### PR TITLE
Custom options for simple_form

### DIFF
--- a/lib/trix/simple_form/trix_editor_input.rb
+++ b/lib/trix/simple_form/trix_editor_input.rb
@@ -2,7 +2,10 @@ module Trix
   module SimpleForm
     class TrixEditorInput < ::SimpleForm::Inputs::Base
       def input(_wrapper_options)
-        editor_tag = template.content_tag('trix-editor', '', input: input_class, class: 'trix-content')
+        trix_options = options.slice(:spellcheck, :toolbar, :tabindex)
+        editor_options = { input: input_class, class: 'trix-content' }.merge(trix_options)
+
+        editor_tag = template.content_tag('trix-editor', '', editor_options)
         hidden_field = @builder.hidden_field(attribute_name, input_html_options)
 
         template.content_tag('div', editor_tag + hidden_field, class: 'trix-editor-wrapper')


### PR DESCRIPTION
If you want to use a custom toolbar with Trix, you can override it using the standard form builder:

```
= f.trix_editor :body, toolbar: 'my-custom-toolbar'
```

When using [simple_form](https://github.com/plataformatec/simple_form), the current code does not allow options to be passed. This pull request allows the toolbar to be set using `simple_form`:

```
= f.input :body, as: :trix_editor, toolbar: 'my-custom-toolbar'
```