### PR TITLE
fix: editor doesn't get populated with stored content

### DIFF
--- a/lib/formtastic/inputs/trix_editor_input.rb
+++ b/lib/formtastic/inputs/trix_editor_input.rb
@@ -9,7 +9,7 @@ class TrixEditorInput < Formtastic::Inputs::StringInput
       editor_tag = template.content_tag('trix-editor', '', editor_tag_params)
       hidden_field = builder.hidden_field(method, input_html_options)
 
-      editor = template.content_tag('div', editor_tag + hidden_field, class: 'trix-editor-wrapper')
+      editor = template.content_tag('div', hidden_field + editor_tag, class: 'trix-editor-wrapper')
 
       label_html + editor
     end


### PR DESCRIPTION
hidden input field must be positioned before trix editor, otherwise trix editor will be initialized without previously stored content.