### PR TITLE
feat: add custom data to trix editor

### DIFF
--- a/lib/trix/simple_form/trix_editor_input.rb
+++ b/lib/trix/simple_form/trix_editor_input.rb
@@ -2,7 +2,7 @@ module Trix
   module SimpleForm
     class TrixEditorInput < ::SimpleForm::Inputs::Base
       def input(_wrapper_options)
-        trix_options = options.slice(:spellcheck, :toolbar, :tabindex, :input)
+        trix_options = options.slice(:spellcheck, :toolbar, :tabindex, :input, :data)
         editor_options = { input: input_class, class: 'trix-content' }.merge(trix_options)
 
         editor_tag = template.content_tag('trix-editor', '', editor_options)

--- a/spec/simple_form/simple_form_integration_spec.rb
+++ b/spec/simple_form/simple_form_integration_spec.rb
@@ -38,6 +38,18 @@ describe Trix::SimpleForm::TrixEditorInput, type: :view do
     end
   end
 
+  context 'with custom data' do
+    let(:form) do
+      simple_form_for(post, url: 'some-url') do |f|
+        f.input(:body, as: :trix_editor, data: { foo: 'bar' })
+      end
+    end
+
+    it 'outputs HTML containing the trix editor tag with a custom data' do
+      assert_select 'trix-editor[data-foo=bar]'
+    end
+  end
+
   context 'with custom toolbar' do
     let(:form) do
       simple_form_for(post, url: 'some-url') do |f|


### PR DESCRIPTION
Allow to do that : 

`= f.input :description, as: :trix_editor, data: { foo: 'bar` }`

Useful to use Hotwire with trix. 
